### PR TITLE
[update] image preview for sign_up and edit

### DIFF
--- a/app/assets/javascripts/preview.js
+++ b/app/assets/javascripts/preview.js
@@ -13,3 +13,12 @@ $(function(){
     });
   });
 });
+
+$(function(){
+  var last_image_input = $('.list-group-item:nth-child(3)')
+  last_image_input.css('display', 'none');
+  $('.list-group-item-plus').on('click', function(){
+    $(this).css('display', 'none');
+    last_image_input.css('display', 'block');
+  });
+});

--- a/app/assets/javascripts/preview.js
+++ b/app/assets/javascripts/preview.js
@@ -1,5 +1,5 @@
 $(function(){
-  $('.img_input').each(function(){
+  $('.img_preview').each(function(){
     var selfInput = $(this).find('input[type=file]');
     selfInput.change(function(){
       var file = selfInput[0].files[0];

--- a/app/assets/javascripts/preview.js
+++ b/app/assets/javascripts/preview.js
@@ -1,8 +1,8 @@
 $(function(){
   $('.img_preview').each(function(){
-    var selfInput = $(this).find('input[type=file]');
-    selfInput.change(function(){
-      var file = selfInput[0].files[0];
+    var $selfInput = $(this).find('input[type=file]');
+    $selfInput.change(function(){
+      var file = $selfInput[0].files[0];
       $img = $(this).siblings('img')
       fileRdr = new FileReader();
       fileRdr.onload = function(event) {
@@ -15,10 +15,10 @@ $(function(){
 });
 
 $(function(){
-  var last_image_input = $('.list-group-item:nth-child(3)')
-  last_image_input.css('display', 'none');
+  var $lastImageInput = $('.list-group-item:nth-child(3)')
+  $lastImageInput.css('display', 'none');
   $('.list-group-item-plus').on('click', function(){
     $(this).css('display', 'none');
-    last_image_input.css('display', 'block');
+    $lastImageInput.css('display', 'block');
   });
 });

--- a/app/assets/stylesheets/protospace.css.scss
+++ b/app/assets/stylesheets/protospace.css.scss
@@ -603,6 +603,19 @@ body {
   z-index: 1030;
 }
 
+.user-new .user-image #user_avatar {
+    display: block;
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    width: 75px;
+    height: 75px;
+    border-radius: 50%;
+}
+
 footer p{
   text-align: center;
 }

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -7,7 +7,8 @@
         .user-name_image.row
           .user-name.col-md-10
             =f.text_field :nickname, placeholder: "Username"
-          .user-image.col-md-2
+          .user-image.col-md-2{class: "img_preview"}
+            = image_tag "", width: "100%", height: "100%", id: "user_avatar", class: "media-object", style: "display: none;"
             %button.btn.btn-primary Add image
             =f.file_field :avator
         =f.email_field :email, placeholder: "E-Mail", class: "user-email"

--- a/app/views/prototypes/prototypes/new.html.haml
+++ b/app/views/prototypes/prototypes/new.html.haml
@@ -11,7 +11,7 @@
         .row
           = f.fields_for :prototype_images do |p|
             .col-md-12
-              .cover-image-upload.img_input
+              .cover-image-upload.img_input.img_preview
                 = p.file_field :name
                 = p.hidden_field :status, value: :main
                 = image_tag "", width: "100%", height: "100%", style: "display: none;"
@@ -20,7 +20,7 @@
                 - 3.times do |i|
                   = f.fields_for :prototype_images do |p|
                     %li.list-group-item.col-md-4
-                      .image-upload.img_input
+                      .image-upload.img_input.img_preview
                         = p.file_field :name
                         = p.hidden_field :status, value: :sub
                         = image_tag "", width: "100%", height: "100%", style: "display: none;"

--- a/app/views/prototypes/prototypes/new.html.haml
+++ b/app/views/prototypes/prototypes/new.html.haml
@@ -25,7 +25,7 @@
                         = p.hidden_field :status, value: :sub
                         = image_tag "", width: "100%", height: "100%", style: "display: none;"
                     - if i == 2
-                      %li.list-group-item.col-md-4{ style: "display:none;" }
+                      %li.list-group-item.col-md-4.list-group-item-plus
                         .image-upload-plus
                           %span +
       .row.proto-description

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -6,7 +6,7 @@
         .user-name_image.row
           .user-name.col-md-10
             = f.text_field :nickname, placeholder: "Username"
-          .user-image.col-md-2{class: "img_preview"}
+          .user-image.col-md-2{ class: "img_preview" }
             = image_tag @user.avator, width: "100%", height: "100%", id: "user_avatar", class: "media-object"
             %button.btn.btn-primary Edit image
             = f.file_field :avator
@@ -24,4 +24,4 @@
           .user-name.col-md-12
             = f.text_area :work, placeholder: "Works", cols: "30", rows: "4"
     .row.text-center.user-btn
-      %button.btn.btn-lg.btn-primary.btn-block{:type => "submit"} Save
+      %button.btn.btn-lg.btn-primary.btn-block{ :type => "submit" } Save

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -6,8 +6,9 @@
         .user-name_image.row
           .user-name.col-md-10
             = f.text_field :nickname, placeholder: "Username"
-          .user-image.col-md-2
-            %button.btn.btn-primary Add image
+          .user-image.col-md-2{class: "img_preview"}
+            = image_tag @user.avator, width: "100%", height: "100%", id: "user_avatar", class: "media-object"
+            %button.btn.btn-primary Edit image
             = f.file_field :avator
       .col-md-12
         %h4 Member of


### PR DESCRIPTION
# WHAT

画像のプレビューを「ユーザー登録画面」、「ユーザー情報編集画面」に実装。
(eachを使用した書き方で適用出来たので、prototypeの登録と同じjsコードを使用しました）

また、プロトタイプの画像登録のプラスボタンのjsを実装。
